### PR TITLE
Update gluon to v2016.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ else
   GLUON_BRANCH := experimental
 endif
 
-JOBS ?= $(shell cat /proc/cpuinfo | grep processor | wc -l)
 JOBS = 1
 
 GLUON_MAKE := ${MAKE} -j ${JOBS} -C ${GLUON_BUILD_DIR} \
@@ -42,23 +41,26 @@ build: gluon-prepare
 
 manifest: build
 	${GLUON_MAKE} manifest
-	mv ${GLUON_BUILD_DIR}/images .
+	mv ${GLUON_BUILD_DIR}/output .
 
 sign: manifest
-	${GLUON_BUILD_DIR}/contrib/sign.sh ${SECRET_KEY_FILE} images/sysupgrade/${GLUON_BRANCH}.manifest
+	${GLUON_BUILD_DIR}/contrib/sign.sh ${SECRET_KEY_FILE} output/images/sysupgrade/${GLUON_BRANCH}.manifest
 
 ${GLUON_BUILD_DIR}:
 	git clone ${GLUON_GIT_URL} ${GLUON_BUILD_DIR}
 
-gluon-prepare: images-clean ${GLUON_BUILD_DIR}
-	(cd ${GLUON_BUILD_DIR} && git fetch origin && git checkout -q ${GLUON_GIT_REF})
+gluon-prepare: output-clean ${GLUON_BUILD_DIR}
+	(cd ${GLUON_BUILD_DIR} \
+	  && git remote set-url origin ${GLUON_GIT_URL} \
+	  && git fetch origin \
+	  && git checkout -q ${GLUON_GIT_REF})
 	ln -sfT .. ${GLUON_BUILD_DIR}/site
 	${GLUON_MAKE} update
 
 gluon-clean:
 	rm -rf ${GLUON_BUILD_DIR}
 
-images-clean:
-	rm -rf images
+output-clean:
+	rm -rf output
 
-clean: gluon-clean images-clean
+clean: gluon-clean output-clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2015.1
+GLUON_GIT_REF := v2016.1.3
 
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,11 @@ SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key
 GLUON_TARGETS ?= \
 	ar71xx-generic \
 	ar71xx-nand \
-	x86-kvm_guest
+	mpc85xx-generic \
+	x86-64 \
+	x86-generic \
+	x86-kvm_guest \
+	x86-xen_domu
 
 GLUON_RELEASE := $(shell git describe --tags 2>/dev/null)
 ifneq (,$(shell git describe --exact-match --tags 2>/dev/null))

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ else
   GLUON_BRANCH := experimental
 endif
 
-JOBS = 1
+JOBS ?= $(shell cat /proc/cpuinfo | grep processor | wc -l)
 
 GLUON_MAKE := ${MAKE} -j ${JOBS} -C ${GLUON_BUILD_DIR} \
 			GLUON_RELEASE=${GLUON_RELEASE} \
-			GLUON_BRANCH=${GLUON_BRANCH} \
+			GLUON_BRANCH=${GLUON_BRANCH}
 
 all: info
 	${MAKE} manifest

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -20,6 +20,7 @@ msgstr ""
 
 msgid "gluon-config-mode:pubkey"
 msgstr ""
+" "
 
 msgid "gluon-config-mode:reboot"
 msgstr ""

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -17,6 +17,7 @@ msgstr ""
 
 msgid "gluon-config-mode:pubkey"
 msgstr ""
+" "
 
 msgid "gluon-config-mode:reboot"
 msgstr ""

--- a/site.conf
+++ b/site.conf
@@ -17,21 +17,37 @@
   regdom = 'DE',
 
   wifi24 = {
-    ssid = 'regensburg.freifunk.net',
     channel = 1,
     htmode = 'HT40+',
-    mesh_ssid = 'mesh.ffrgb',
-    mesh_bssid = '02:0E:8E:1E:61:17',
-    mesh_mcast_rate = 12000,
+    ap = {
+      ssid = 'regensburg.freifunk.net',
+    },
+    mesh = {
+      id = 'ffrgb-mesh',
+      mcast_rate = 12000,
+    },
+    ibss = {
+      ssid = 'mesh.ffrgb',
+      bssid = '02:0E:8E:1E:61:17',
+      mcast_rate = 12000,
+    },
   },
 
   wifi5 = {
-    ssid = 'regensburg.freifunk.net',
     channel = 44,
     htmode = 'HT40+',
-    mesh_ssid = 'mesh.ffrgb',
-    mesh_bssid = '02:0E:8E:1E:61:17',
-    mesh_mcast_rate = 12000,
+    ap = {
+      ssid = 'regensburg.freifunk.net',
+    },
+    mesh = {
+      id = 'ffrgb-mesh',
+      mcast_rate = 12000,
+    },
+    ibss = {
+      ssid = 'mesh.ffrgb',
+      bssid = '02:0E:8E:1E:61:17',
+      mcast_rate = 12000,
+    },
   },
 
   next_node = {

--- a/site.conf
+++ b/site.conf
@@ -2,7 +2,9 @@
   hostname_prefix = 'freifunk-rgb_',
   site_name = 'Freifunk Regensburg',
   site_code = 'ffrgb-bat15',
-  opkg_repo = 'http://openwrt.draic.info/barrier_breaker/14.07/%S/packages',
+  opkg = {
+    openwrt = 'http://openwrt.draic.info/%n/%v/%S/packages',
+  },
 
   prefix4 = '10.90.0.0/16',
   prefix6 = 'fdef:f00f:1337:cafe/64',

--- a/site.conf
+++ b/site.conf
@@ -18,7 +18,6 @@
 
   wifi24 = {
     channel = 1,
-    htmode = 'HT40+',
     ap = {
       ssid = 'regensburg.freifunk.net',
     },
@@ -35,7 +34,6 @@
 
   wifi5 = {
     channel = 44,
-    htmode = 'HT40+',
     ap = {
       ssid = 'regensburg.freifunk.net',
     },

--- a/site.conf
+++ b/site.conf
@@ -77,6 +77,11 @@
         },
       },
     },
+    bandwidth_limit = {
+      enabled = false,
+      egress = 1200,
+      ingress = 12000,
+    },
   },
 
   autoupdater = {
@@ -110,13 +115,5 @@
     },
   },
 
-  simple_tc = {
-    mesh_vpn = {
-      ifname = 'mesh-vpn',
-      enabled = false,
-      limit_egress = 1200,
-      limit_ingress = 12000,
-    },
-  },
 }
 -- vim: set ft=lua:ts=2:sw=2:et

--- a/site.mk
+++ b/site.mk
@@ -28,6 +28,175 @@ GLUON_SITE_PACKAGES := \
 	gluon-ebtables-filter-multicast-ffmuc
 
 
+# basic support for USB stack
+USB_PACKAGES_BASIC := \
+	kmod-usb-core \
+	kmod-usb2
+
+# storage support for USB devices
+USB_PACKAGES_STORAGE := \
+	block-mount \
+	blkid \
+	kmod-fs-ext4 \
+	kmod-fs-vfat \
+	kmod-usb-storage \
+	kmod-usb-storage-extras \
+	kmod-nls-cp1250 \
+	kmod-nls-cp1251 \
+	kmod-nls-cp437 \
+	kmod-nls-cp775 \
+	kmod-nls-cp850 \
+	kmod-nls-cp852 \
+	kmod-nls-cp866 \
+	kmod-nls-iso8859-1 \
+	kmod-nls-iso8859-13 \
+	kmod-nls-iso8859-15 \
+	kmod-nls-iso8859-2 \
+	kmod-nls-koi8r \
+	kmod-nls-utf8 \
+	swap-utils
+
+# network support for USB devices
+USB_PACKAGES_NET := \
+	kmod-mii \
+	kmod-nls-base \
+	kmod-usb-net \
+	kmod-usb-net-asix \
+	kmod-usb-net-asix-ax88179 \
+	kmod-usb-net-cdc-eem \
+	kmod-usb-net-cdc-ether \
+	kmod-usb-net-cdc-mbim \
+	kmod-usb-net-cdc-ncm \
+	kmod-usb-net-cdc-subset \
+	kmod-usb-net-dm9601-ether \
+	kmod-usb-net-hso \
+	kmod-usb-net-huawei-cdc-ncm \
+	kmod-usb-net-ipheth \
+	kmod-usb-net-kalmia \
+	kmod-usb-net-kaweth \
+	kmod-usb-net-mcs7830 \
+	kmod-usb-net-pegasus \
+	kmod-usb-net-qmi-wwan \
+	kmod-usb-net-rndis \
+	kmod-usb-net-rtl8152 \
+	kmod-usb-net-sierrawireless \
+	kmod-usb-net-smsc95xx
+# broken
+#	kmod-usb-net-rtl8150 \
+# additional USB network devices (ie Edimax)
+USB_PACKAGES_NET_ADD := \
+	kmod-rtl8192cu \
+	kmod-rtl8187 \
+	kmod-ath9k-htc  \
+	kmod-ath9k-common \
+	kmod-ath \
+	kmod-rt73-usb \
+	kmod-carl9170 \
+	kmod-brcmfmac
+
+# network support for PCI devices
+PCI_PACKAGES_NET := \
+	kmod-3c59x \
+	kmod-e100 \
+	kmod-e1000 \
+	kmod-e1000e \
+	kmod-forcedeth \
+	kmod-natsemi \
+	kmod-ne2k-pci \
+	kmod-pcnet32 \
+	kmod-r8169 \
+	kmod-sis900 \
+	kmod-sky2 \
+	kmod-tg3 \
+	kmod-tulip \
+	kmod-via-rhine
+# broken
+#	kmod-ixgbe \
+#	kmod-r8139too \
+# additional packages
+TOOLS_PACKAGES := \
+	iperf \
+	socat \
+	tcpdump \
+	usbutils \
+	vnstat
+# broken
+#	pciutils \
+
+#
+# $(GLUON_TARGET) specific settings:
+#
+
+# x86-generic
+ifeq ($(GLUON_TARGET),x86-generic)
+# support the usb stack on x86 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES) \
+	$(USB_PACKAGES_NET_ADD)
+endif
+
+# x86-64
+ifeq ($(GLUON_TARGET),x86-64)
+# support the usb stack on x86-64 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES) \
+	$(USB_PACKAGES_NET_ADD)
+endif
+
+# Raspberry Pi A/B/B+
+ifeq ($(GLUON_TARGET),brcm2708-bcm2708)
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(TOOLS_PACKAGES) \
+	$(USB_PACKAGES_NET_ADD)
+endif
+
+# Raspberry Pi 2
+ifeq ($(GLUON_TARGET),brcm2708-bcm2709)
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(TOOLS_PACKAGES) \
+	$(USB_PACKAGES_NET_ADD)
+endif
+
+# ar71xx-generic
+GLUON_TLWR842_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR1043_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR2543_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWDR4300_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WNDR3700_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WRT160NL_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_ARCHERC7_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_GLINET_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPG450H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+# mpc85xx-generic
+GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+
 DEFAULT_GLUON_RELEASE := snapshot~$(shell date '+%Y%m%d')
 
 # Allow overriding the release number from the command line

--- a/site.mk
+++ b/site.mk
@@ -1,7 +1,7 @@
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-15 \
 	gluon-alfred \
-	gluon-announced \
+	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-core \
 	gluon-config-mode-autoupdater \


### PR DESCRIPTION
# Changes
- **update:** Gluon to v2016.1.3
- **update:** site.conf to new syntay format
- **update:** increase number of jobs to speed up build process
- **update:** change image dir to output/image
- **add:** support for all stable targets
- **add:** support for several usb devices
- **fix:** always hide the fastd key in wizard
## TODO
- [ ] update build dependencies at [ffrgb website](https://regensburg.freifunk.net/technik/firmware-bauen/) to `sudo apt-get install git subversion python build-essential gawk unzip libncurses5-dev zlib1g-dev libssl-dev` [(ref)](http://gluon.readthedocs.org/en/v2016.1.3/user/getting_started.html)
- [ ] update device list at [ffrgb website](https://regensburg.freifunk.net/mitmachen/router-aufstellen/)
- [ ] update [`gluon-packages`](https://github.com/ffrgb/gluon-packages), cherry-pick [this commit](https://github.com/freifunkMUC/gluon-packages/commit/d4d5aa3e3874ca6099e91fd70008ad5d54038169)
## Tested
#### runtime-tested:
- ar71xx-generic (TP-Link TL-WR841N v10)
#### compile-tested only:
- ar71xx-nand
- mpc85xx-generic
- x86-64
- x86-generic
- x86-kvm_guest
- x86-xen_domu
## References

http://gluon.readthedocs.org/en/v2016.1.3/releases/v2016.1.html
https://github.com/freifunkMUC/site-ffm
